### PR TITLE
feat: Add responsive layout for wider screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# DeftDawg's Unofficial fork of [Good Display's NeoFrame HTML page](http://www.einkapp.com/esp32-133c02.html) 
+for 13.3" Spectra 6 displays driven by w/ [ESP32-133C02](https://www.good-display.com/product/574.html)
+
+Adds:
+- rotation
+- scaling
+- QR code overlays
+- 8x10 Ikea RODALM frame fit
+
+<img width="1961" height="1823" alt="image" src="https://github.com/user-attachments/assets/b5cfd834-e339-4dad-99c5-2332c2f0b3e4" />

--- a/neoframe.html
+++ b/neoframe.html
@@ -233,6 +233,26 @@
                 font-size: 0.9em;
             }
         }
+
+        /* Responsive layout for wider screens */
+        @media (min-width: 1300px) {
+            .page-container {
+                flex-direction: row;
+                align-items: flex-start;
+                gap: 20px;
+            }
+            .controls-container {
+                width: 600px;
+                flex-shrink: 0;
+                position: sticky;
+                top: 20px;
+            }
+            #canvas {
+                flex-grow: 1;
+                max-width: calc(100% - 620px);
+                height: auto;
+            }
+        }
     </style>
     <script src="scripts/exif.js"></script>
     <script type="text/javascript" src="scripts/qrcode.js"></script>


### PR DESCRIPTION
This commit introduces a CSS media query to adjust the layout for screens wider than 1300px.

On wider screens, the image preview canvas is now positioned to the right of the controls, providing a better user experience on desktops. The controls container is made sticky to remain visible during scrolling.

On narrower screens, the layout remains as it was, with the preview below the controls, ensuring a good experience on mobile devices.